### PR TITLE
Prevent infinite scroll

### DIFF
--- a/addons/carmel4a97.RTS_Camera2D/Plugin.gd
+++ b/addons/carmel4a97.RTS_Camera2D/Plugin.gd
@@ -23,7 +23,7 @@ tool
 extends EditorPlugin
 
 func _enter_tree():
-	 add_custom_type("RTS-Camera2D", "Camera2D", preload("RTS-Camera2D.gd"), preload("node_icon.png"))
+	add_custom_type("RTS-Camera2D", "Camera2D", preload("RTS-Camera2D.gd"), preload("node_icon.png"))
 
 func _exit_tree():
 	remove_custom_type("RTS-Camera2D")

--- a/addons/carmel4a97.RTS_Camera2D/RTS-Camera2D.gd
+++ b/addons/carmel4a97.RTS_Camera2D/RTS-Camera2D.gd
@@ -25,32 +25,32 @@ extends Camera2D
 # drag - by clicking mouse button, right mouse button by default;
 # edge - by moving mouse to the window edge
 # wheel - zoom in/out by mouse wheel
-export (bool) var key = true
-export (bool) var drag = true
-export (bool) var edge = false
-export (bool) var wheel = true
+@export var key: bool = true
+@export var drag: bool = true
+@export var edge: bool = false
+@export var wheel: bool = true
 
-export (int) var zoom_out_limit = 100
+@export var zoom_out_limit: int = 100
 
 # Camera speed in px/s.
-export (int) var camera_speed = 450 
+@export var camera_speed: int = 450 
 
 # Initial zoom value taken from Editor.
 var camera_zoom = get_zoom()
 
 # Value meaning how near to the window edge (in px) the mouse must be,
 # to move a view.
-export (int) var camera_margin = 50
+@export var camera_margin: int = 50
 
 # It changes a camera zoom value in units... (?, but it works... it probably
 # multiplies camera size by 1+camera_zoom_speed)
-const camera_zoom_speed = Vector2(0.5, 0.5)
+const camera_zoom_speed: Vector2 = Vector2(0.5, 0.5)
 
 # Vector of camera's movement / second.
-var camera_movement = Vector2()
+var camera_movement: Vector2 = Vector2()
 
 # Previous mouse position used to count delta of the mouse movement.
-var _prev_mouse_pos = null
+var _prev_mouse_pos: Vector2 = Vector2.ZERO
 
 # INPUTS
 
@@ -60,10 +60,10 @@ var __rmbk = false
 var __keys = [false, false, false, false]
 
 func _ready():
-	set_h_drag_enabled(false)
-	set_v_drag_enabled(false)
-	set_enable_follow_smoothing(true)
-	set_follow_smoothing(4)
+	set_drag_horizontal_enabled(false)
+	set_drag_vertical_enabled(false)
+	set_position_smoothing_enabled(true)
+	set_position_smoothing_speed(4)
 
 func _physics_process(delta):
 	
@@ -105,7 +105,7 @@ func _physics_process(delta):
 func _unhandled_input( event ):
 	if event is InputEventMouseButton:
 		if drag and\
-		   event.button_index == BUTTON_RIGHT:
+			event.button_index == MOUSE_BUTTON_RIGHT:
 			# Control by right mouse button.
 			if event.pressed: __rmbk = true
 			else: __rmbk = false
@@ -113,13 +113,13 @@ func _unhandled_input( event ):
 		if wheel:
 			# Checking if future zoom won't be under 0.
 			# In that cause engine will flip screen.
-			if event.button_index == BUTTON_WHEEL_UP and\
+			if event.button_index == MOUSE_BUTTON_WHEEL_UP and\
 			camera_zoom.x - camera_zoom_speed.x > 0 and\
 			camera_zoom.y - camera_zoom_speed.y > 0:
 				camera_zoom -= camera_zoom_speed
 				set_zoom(camera_zoom)
 				# Checking if future zoom won't be above zoom_out_limit.
-			if event.button_index == BUTTON_WHEEL_DOWN and\
+			if event.button_index == MOUSE_BUTTON_WHEEL_DOWN and\
 			camera_zoom.x + camera_zoom_speed.x < zoom_out_limit and\
 			camera_zoom.y + camera_zoom_speed.y < zoom_out_limit:
 				camera_zoom += camera_zoom_speed

--- a/addons/carmel4a97.RTS_Camera2D/RTS-Camera2D.gd
+++ b/addons/carmel4a97.RTS_Camera2D/RTS-Camera2D.gd
@@ -104,8 +104,8 @@ func _physics_process(delta):
 	var actual_left_limit = viewport.end.x * zoom.x / 2
 	var actual_top_limit = viewport.end.y * zoom.y / 2
 	
-	position.x = clamp(position.x, actual_left_limit, limit_right - actual_left_limit)
-	position.y = clamp(position.y, actual_top_limit, limit_bottom - actual_top_limit)
+	position.x = clamp(position.x, limit_left + actual_left_limit, limit_right - actual_left_limit)
+	position.y = clamp(position.y, limit_top + actual_top_limit, limit_bottom - actual_top_limit)
 	
 	# Set camera movement to zero, update old mouse position.
 	camera_movement = Vector2(0,0)

--- a/addons/carmel4a97.RTS_Camera2D/RTS-Camera2D.gd
+++ b/addons/carmel4a97.RTS_Camera2D/RTS-Camera2D.gd
@@ -66,7 +66,6 @@ func _ready():
 	set_position_smoothing_speed(4)
 
 func _physics_process(delta):
-	
 	# Move camera by keys defined in InputMap (ui_left/top/right/bottom).
 	if key:
 		if __keys[0]:
@@ -97,15 +96,12 @@ func _physics_process(delta):
 	
 	# Update position of the camera.
 	position += camera_movement * get_zoom()
-	
-	# Clamp camera to bounds - used so that we cannot keep scrolling forever.
-	var zoom = get_zoom()
-	var viewport = get_viewport_rect()
-	var actual_left_limit = viewport.end.x * zoom.x / 2
-	var actual_top_limit = viewport.end.y * zoom.y / 2
-	
-	position.x = clamp(position.x, limit_left + actual_left_limit, limit_right - actual_left_limit)
-	position.y = clamp(position.y, limit_top + actual_top_limit, limit_bottom - actual_top_limit)
+
+#	force camera to center of screen positionally
+	var center = get_screen_center_position()
+	var current_target = get_target_position()
+	if current_target != center:
+		position = center
 	
 	# Set camera movement to zero, update old mouse position.
 	camera_movement = Vector2(0,0)

--- a/addons/carmel4a97.RTS_Camera2D/RTS-Camera2D.gd
+++ b/addons/carmel4a97.RTS_Camera2D/RTS-Camera2D.gd
@@ -98,6 +98,15 @@ func _physics_process(delta):
 	# Update position of the camera.
 	position += camera_movement * get_zoom()
 	
+	# Clamp camera to bounds - used so that we cannot keep scrolling forever.
+	var zoom = get_zoom()
+	var viewport = get_viewport_rect()
+	var actual_left_limit = viewport.end.x * zoom.x / 2
+	var actual_top_limit = viewport.end.y * zoom.y / 2
+	
+	position.x = clamp(position.x, actual_left_limit, limit_right - actual_left_limit)
+	position.y = clamp(position.y, actual_top_limit, limit_bottom - actual_top_limit)
+	
 	# Set camera movement to zero, update old mouse position.
 	camera_movement = Vector2(0,0)
 	_prev_mouse_pos = get_local_mouse_position()


### PR DESCRIPTION
Fix camera scroll from going past edge of bounds.

[Issue](https://github.com/carmel4a/RTS-Camera2D/issues/3)